### PR TITLE
Add roo-xls since it is now required

### DIFF
--- a/src/excel2csv.rb
+++ b/src/excel2csv.rb
@@ -3,6 +3,7 @@
 
 require 'rubygems'
 require 'roo'
+require 'roo-xls'
 require 'csv'
 
 USAGE = <<END

--- a/src/excel2csv.rb
+++ b/src/excel2csv.rb
@@ -1,5 +1,5 @@
-# encoding: UTF-8
 #!/usr/bin/env ruby
+# encoding: UTF-8
 
 require 'rubygems'
 require 'roo'


### PR DESCRIPTION
Corrects the following:
`/Library/Ruby/Gems/2.0.0/gems/roo-2.5.1/lib/roo.rb:24:in 'const_missing': Excel support has been extracted to roo-xls due to its dependency on the GPL'd spreadsheet gem. Install roo-xls to use Roo::Excel. (RuntimeError)
    from excel2csv.rb:33:in '<main>'`
